### PR TITLE
Fix rate limiting for API calls

### DIFF
--- a/aso/views.py
+++ b/aso/views.py
@@ -229,11 +229,6 @@ def search_view(request):
     for country in countries:
         country_results = []
         for kw_text in keywords:
-            # Rate limit between API calls
-            if call_count > 0:
-                time.sleep(2)
-            call_count += 1
-
             # Get or create keyword
             keyword_obj, created = Keyword.objects.get_or_create(
                 keyword=kw_text.lower(),
@@ -247,6 +242,11 @@ def search_view(request):
             ).exists():
                 skipped.append(f"{kw_text} ({country.upper()})")
                 continue
+
+            # Rate limit between API calls
+            if call_count > 0:
+                time.sleep(2)
+            call_count += 1
 
             # iTunes Search
             competitors = itunes_service.search_apps(kw_text, country=country, limit=25)


### PR DESCRIPTION
## fix: skip rate-limit delay for duplicate keywords

Previously, the 2-second rate-limit sleep between iTunes API calls was placed before the duplicate check, causing unnecessary delays even when all submitted keywords were already in the database for today. 

This change moves the `time.sleep(2)` to after the duplicate check, so the delay only applies when an actual iTunes API call is about to be made.

### Changes
- `aso/views.py`: Reordered logic in `search_view` so the duplicate-today check runs before the rate-limit sleep, not after.

### Before / After

**Before:** `sleep → get_or_create → duplicate check → API call`  
**After:** `get_or_create → duplicate check → sleep → API call`
